### PR TITLE
test: switch to rstest-based tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,9 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "lset"
 version = "0.2.0"
-source = "git+https://github.com/enarx/lset?branch=main#c63f8c10bf8740765d2a669f892ce61a74087314"
+source = "git+https://github.com/enarx/lset?branch=main#5c2feed24d85442725f55d812315854e1b29595d"
 
 [[package]]
 name = "mmledger"
@@ -20,9 +26,73 @@ dependencies = [
  "bitflags",
  "lset",
  "primordial",
+ "rstest",
 ]
 
 [[package]]
 name = "primordial"
 version = "0.4.0"
 source = "git+https://github.com/enarx/primordial?branch=main#b606b9e472e2238384b003f12fdada077e04d2fe"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rstest"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d912f35156a3f99a66ee3e11ac2e0b3f34ac85a07e05263d05a7e2c8810d616f"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
+
+[[package]]
+name = "syn"
+version = "1.0.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,6 @@ include = [
 bitflags = "1.0.4"
 lset = { git = "https://github.com/enarx/lset", branch = "main" }
 primordial = { git = "https://github.com/enarx/primordial", branch = "main" }
+
+[dev-dependencies]
+rstest = "0.12.0"


### PR DESCRIPTION
Testing was getting overly complex. To manage this better, switch to
`rstest` for parameterized tests.

Unfortunately, this also revealed a lot of bugs. I rewrote `.add()` to
pass all tests. However, `.delete()` still fails most tests.

Signed-off-by: Nathaniel McCallum <nathaniel@profian.com>

cc @jarkkojs 