### PR TITLE
fix: add the missing skip

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,12 @@ impl<const N: usize> Ledger<N> {
             let record_start = self.records[index].region.start;
             let record_end = self.records[index].region.end;
 
+            if region.end < record_start || region.start > record_end {
+                // Skip:
+                index += 1;
+                continue;
+            }
+
             if region.start <= record_start && region.end >= record_end {
                 self.remove(index);
                 // Jump without `index += 1` so that a left-shifted record will


### PR DESCRIPTION
Skip for out-of-range records.

Signed-off-by: Jarkko Sakkinen <jarkko@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
