### PR TITLE
chore: add standardized codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,4 @@
-*	@npmccallum @jarkkojs @haraldh @bstrie
+# Each line is a file pattern followed by one or more owners.
+# Owners will be automatically notified about new PRs and
+# an owner's approval is required to merge to protected branches.
+*       @enarx/codeowners

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,9 +228,7 @@ impl<const N: usize> Ledger<N> {
         let region = Region::new(addr, addr + length);
 
         // Clear out the possibly reserved space for the new record.
-        if let Err(err) = self.unmap(addr, length) {
-            return Err(err);
-        }
+        self.unmap(addr, length)?;
 
         match self.records().len() {
             0 => self.insert(0, Record { region, access }).and(self.merge()),


### PR DESCRIPTION
Signed-off-by: bstrie <865233+bstrie@users.noreply.github.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
