### PR TITLE
ci: add code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,46 @@
+name: coverage
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          components: llvm-tools-preview
+          toolchain: stable
+          override: true
+
+      - name: Install lcov
+        run: |
+          sudo apt -o Acquire::Retries=3 update
+          sudo apt -o Acquire::Retries=3 install -y lcov
+
+      - name: Install cargo-llvm-cov
+        run: >
+          curl -LsSf 'https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.5.2/cargo-llvm-cov-x86_64-unknown-linux-musl.tar.gz'
+          | tar xzf -
+          && mv cargo-llvm-cov $HOME/.cargo/bin
+
+      - name: Run cargo-llvm-cov
+        run: cargo llvm-cov --lcov --output-path lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          directory: ./
+          files: ./lcov.info
+          fail_ci_if_error: false
+          verbose: true
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,11 @@
-on: [push, pull_request]
 name: test
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ${{ matrix.toolchain }} (${{ matrix.profile.name }})
@@ -21,7 +27,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.57.0
+          - 1.60.0
         profile:
           - name: debug
           - name: release

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.57"
+channel = "1.60"
 profile = "minimal"


### PR DESCRIPTION
and bump minimal version to 1.60 for llvm-cov

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
