### PR TITLE
chore: fix .gitignore and Cargo.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.idea
+/.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,7 @@ repository = "https://github.com/enarx/mmledger"
 description = "A ledger for confidential computing (CC) shims for tracking memory management system calls"
 edition = "2021"
 rust-version = "1.57"
-include = [
-    "**/*.rs",
-    "Cargo.toml",
-]
+exclude = [".github/"]
 
 [dependencies]
 bitflags = "1.0.4"


### PR DESCRIPTION
otherwise `README.md` is not in the package, but is included from lib.rs

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://enarx.dev/docs/contributing/code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
